### PR TITLE
Enhance markdown-driven news pages

### DIFF
--- a/src/app/news/[slug]/page.tsx
+++ b/src/app/news/[slug]/page.tsx
@@ -1,0 +1,54 @@
+import type { Metadata } from "next";
+import Image from "next/image";
+import Container from "@/components/Container";
+import { getAllNews, getNewsBySlug, markdownToHtml } from "@/data/news";
+
+interface Params {
+    params: { slug: string };
+}
+
+export async function generateStaticParams() {
+    const news = getAllNews();
+    return news.map(item => ({ slug: item.slug }));
+}
+
+export function generateMetadata({ params }: Params): Metadata {
+    const article = getNewsBySlug(params.slug);
+    return {
+        title: `${article.title} - Xtara`,
+        description: article.description,
+    };
+}
+
+const NewsDetailPage = ({ params }: Params) => {
+    const article = getNewsBySlug(params.slug);
+    const html = markdownToHtml(article.content);
+
+    return (
+        <Container>
+            <article className="max-w-3xl mx-auto py-12">
+                {article.image && (
+                    <Image
+                        src={article.image}
+                        alt={article.title}
+                        width={800}
+                        height={400}
+                        className="w-full h-64 object-cover rounded-lg mt-6 mb-6"
+                    />
+                )}
+                <h1 className="text-4xl font-bold text-ocean-navy mb-4">{article.title}</h1>
+                <p className="text-sm text-gray-600 mb-8">
+                    {new Date(article.date).toLocaleDateString()}
+                </p>
+                <div
+                    className="prose prose-lg max-w-none"
+                    dangerouslySetInnerHTML={{ __html: html }}
+                />
+            </article>
+        </Container>
+    );
+};
+
+export default NewsDetailPage;
+
+

--- a/src/app/news/page.tsx
+++ b/src/app/news/page.tsx
@@ -1,0 +1,80 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import Image from "next/image";
+import Container from "@/components/Container";
+import { getAllNews } from "@/data/news";
+
+export const metadata: Metadata = {
+    title: "News - Xtara",
+    description: "Latest updates and news from Xtara.",
+};
+
+export const dynamic = "force-dynamic";
+
+const PAGE_SIZE = 10;
+
+const NewsPage = ({ searchParams }: { searchParams?: { page?: string } }) => {
+    const newsItems = getAllNews();
+    const page = parseInt(searchParams?.page || "1", 10);
+    const start = (page - 1) * PAGE_SIZE;
+    const paginated = newsItems.slice(start, start + PAGE_SIZE);
+    const totalPages = Math.ceil(newsItems.length / PAGE_SIZE);
+
+    return (
+        <Container>
+            <div className="max-w-5xl mx-auto py-12">
+                <h1 className="text-4xl font-bold text-ocean-navy mb-8">News</h1>
+                <ul className="space-y-8">
+                    {paginated.map(item => (
+                        <li key={item.slug}>
+                            <Link
+                                href={`/news/${item.slug}`}
+                                className="block rounded-lg overflow-hidden bg-cream-sand hover:bg-cream-sand/80 transition-colors"
+                            >
+                                <div className={item.image ? "md:flex" : ""}>
+                                    {item.image && (
+                                        <Image
+                                            src={item.image}
+                                            alt={item.title}
+                                            width={400}
+                                            height={250}
+                                            className="w-full md:w-64 h-48 object-cover md:mr-6 mb-4 md:mb-0"
+                                        />
+                                    )}
+                                    <div className="p-6">
+                                        <p className="text-sm text-gray-600 mb-2">
+                                            {new Date(item.date).toLocaleDateString()}
+                                        </p>
+                                        <h2 className="text-2xl font-semibold text-ocean-navy">
+                                            {item.title}
+                                        </h2>
+                                        <p className="text-gray-700 mt-2">{item.description}</p>
+                                    </div>
+                                </div>
+                            </Link>
+                        </li>
+                    ))}
+                </ul>
+                {totalPages > 1 && (
+                    <div className="flex justify-between mt-8">
+                        {page > 1 ? (
+                            <Link href={`/news?page=${page - 1}`} className="text-ocean-navy font-semibold">
+                                Previous
+                            </Link>
+                        ) : (
+                            <span />
+                        )}
+                        {page < totalPages && (
+                            <Link href={`/news?page=${page + 1}`} className="ml-auto text-ocean-navy font-semibold">
+                                Next
+                            </Link>
+                        )}
+                    </div>
+                )}
+            </div>
+        </Container>
+    );
+};
+
+export default NewsPage;
+

--- a/src/data/menuItems.ts
+++ b/src/data/menuItems.ts
@@ -4,5 +4,9 @@ export const menuItems: IMenuItem[] = [
     {
         text: "Features",
         url: "#features"
+    },
+    {
+        text: "News",
+        url: "/news"
     }
 ];

--- a/src/data/news/events.md
+++ b/src/data/news/events.md
@@ -1,0 +1,8 @@
+---
+title: "Upcoming Career Events"
+date: "2025-03-10"
+---
+
+Join us for a series of webinars and workshops designed to help you make informed career choices.
+Our experts will cover resume building, interview tips, and more throughout the spring.
+

--- a/src/data/news/index.ts
+++ b/src/data/news/index.ts
@@ -1,0 +1,96 @@
+import fs from 'fs';
+import path from 'path';
+import { INewsArticle, INewsMeta } from '@/types';
+
+const newsDirectory = path.join(process.cwd(), 'src', 'data', 'news');
+
+interface FrontMatterResult {
+    data: Record<string, string>;
+    content: string;
+}
+
+const parseFrontMatter = (fileContents: string): FrontMatterResult => {
+    const delimiter = '---';
+    if (!fileContents.startsWith(delimiter)) {
+        return { data: {}, content: fileContents };
+    }
+    const end = fileContents.indexOf(delimiter, delimiter.length);
+    const raw = fileContents.slice(delimiter.length, end).trim();
+    const content = fileContents.slice(end + delimiter.length).trim();
+
+    const data: Record<string, string> = {};
+    raw.split('\n').forEach(line => {
+        const [key, ...rest] = line.split(':');
+        if (key) {
+            data[key.trim()] = rest.join(':').trim().replace(/^"|"$/g, '');
+        }
+    });
+
+    return { data, content };
+};
+
+const getExcerpt = (content: string): string => {
+    const line = content
+        .split('\n')
+        .find(l => l.trim() && !l.startsWith('#')) || '';
+    return line.trim().slice(0, 160);
+};
+
+export const getAllNews = (): INewsMeta[] => {
+    const files = fs.readdirSync(newsDirectory);
+    const items: INewsMeta[] = files
+        .filter(file => file.endsWith('.md'))
+        .map(file => {
+            const fullPath = path.join(newsDirectory, file);
+            const fileContents = fs.readFileSync(fullPath, 'utf8');
+            const { data, content } = parseFrontMatter(fileContents);
+            return {
+                slug: file.replace(/\.md$/, ''),
+                title: data.title,
+                date: data.date,
+                image: data.image,
+                description: getExcerpt(content),
+            } as INewsMeta;
+        })
+        .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+    return items;
+};
+
+export const getNewsBySlug = (slug: string): INewsArticle => {
+    const fullPath = path.join(newsDirectory, `${slug}.md`);
+    const fileContents = fs.readFileSync(fullPath, 'utf8');
+    const { data, content } = parseFrontMatter(fileContents);
+    return {
+        slug,
+        title: data.title,
+        date: data.date,
+        image: data.image,
+        description: getExcerpt(content),
+        content,
+    } as INewsArticle;
+};
+
+export const markdownToHtml = (markdown: string): string => {
+    const lines = markdown.split('\n');
+    const html = lines
+        .map(line => {
+            if (line.startsWith('### ')) {
+                return `<h3>${line.substring(4)}</h3>`;
+            }
+            if (line.startsWith('## ')) {
+                return `<h2>${line.substring(3)}</h2>`;
+            }
+            if (line.startsWith('# ')) {
+                return `<h1>${line.substring(2)}</h1>`;
+            }
+            if (line.trim() === '') {
+                return '';
+            }
+            return `<p>${line}</p>`;
+        })
+        .join('\n');
+
+    return html;
+};
+
+

--- a/src/data/news/launch.md
+++ b/src/data/news/launch.md
@@ -1,0 +1,10 @@
+---
+title: "Xtara Launches Career Guidance Platform"
+date: "2025-01-01"
+image: "/images/001.png"
+---
+
+Welcome to the official launch of Xtara, your new companion for finding the perfect career path. Our platform uses advanced assessments and personalized recommendations to guide students and professionals toward fulfilling careers.
+
+Stay tuned for updates and success stories as we grow!
+

--- a/src/data/news/update.md
+++ b/src/data/news/update.md
@@ -1,0 +1,10 @@
+---
+title: "New Features Added to Xtara"
+date: "2025-02-15"
+image: "/images/002.png"
+---
+
+We've rolled out new features including detailed college matching and a redesigned dashboard. These improvements make it easier to explore your options and plan your future.
+
+Try them out today and let us know what you think!
+

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,3 +51,15 @@ export interface ISocials {
     x?: string;
     [key: string]: string | undefined;
 }
+
+export interface INewsMeta {
+    slug: string;
+    title: string;
+    date: string;
+    image?: string;
+    description: string;
+}
+
+export interface INewsArticle extends INewsMeta {
+    content: string;
+}


### PR DESCRIPTION
## Summary
- include descriptions and optional images in news data
- add margins to list images and support image-less articles
- paginate news list when more than ten posts
- mark news list page as dynamic to avoid static generation conflicts

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890568736888331aac5117d15a40761